### PR TITLE
Fix petition re-add

### DIFF
--- a/httpdocs/app/js/app.js
+++ b/httpdocs/app/js/app.js
@@ -1112,7 +1112,7 @@ function showMenu(){
         } else { // remove useless fields, keep only done and fingerprint
           delete proposal.id; // hidden
           delete proposal.published;
-          delete proposal.signature;
+          delete proposal.participants;
           delete proposal.title;
           delete proposal.description;
           delete proposal.areas;

--- a/httpdocs/app/js/app.js
+++ b/httpdocs/app/js/app.js
@@ -1109,7 +1109,7 @@ function showMenu(){
           proposals.forEach(function(p) {
             p.id = i++;
           });
-        } else { // remove useless fields, keep only done and fingerprint
+        } else { // remove useless fields, keep only done and signature
           delete proposal.id; // hidden
           delete proposal.published;
           delete proposal.participants;


### PR DESCRIPTION
Fix #17 

- Keep the signature instead of the fingerprint (the fingerprint was actually not even kept) when the petition is removed
- Do not keep the number of participants when the petition is removed
- Allow to add a petition that was already signed, but with `sign` button set to `signed`